### PR TITLE
Fix: `bilibili-api` 移除不必要的 `w_webid` 获取方法

### DIFF
--- a/src/utils/bilibili_api/api/user.py
+++ b/src/utils/bilibili_api/api/user.py
@@ -8,18 +8,11 @@
 @Software       : PyCharm
 """
 
-from urllib.parse import unquote
-
-from lxml import etree
-from nonebot.utils import run_sync
-
-from src.compat import parse_json_as
 from .base import BilibiliCommon
 from ..models import (
     Account,
     User,
     UserSearchResult,
-    UserSpaceRenderData,
     VipInfo,
 )
 

--- a/src/utils/bilibili_api/api/user.py
+++ b/src/utils/bilibili_api/api/user.py
@@ -41,27 +41,11 @@ class BilibiliUser(BilibiliCommon):
         data = await cls._get_json(url=url)
         return VipInfo.model_validate(data)
 
-    @staticmethod
-    @run_sync
-    def _parse_user_space_w_webid(content: str) -> UserSpaceRenderData:
-        """解析用户页面 __RENDER_DATA__ 内容"""
-        html = etree.HTML(content)
-        render_data = html.xpath('/html/head/script[@id="__RENDER_DATA__"]').pop(0).text
-        return parse_json_as(UserSpaceRenderData, unquote(render_data))
-
-    @classmethod
-    async def _query_user_space_w_webid(cls, mid: int | str) -> UserSpaceRenderData:
-        """获取并解析用户页面 __RENDER_DATA__ 内容"""
-        user_space_url = f'https://space.bilibili.com/{mid}'
-        user_space_page = await cls._get_resource_as_text(url=user_space_url)
-        return await cls._parse_user_space_w_webid(content=user_space_page)
-
     @classmethod
     async def query_user_info(cls, mid: int | str) -> User:
         """获取用户基本信息"""
         url = 'https://api.bilibili.com/x/space/wbi/acc/info'
-        render_data = await cls._query_user_space_w_webid(mid=mid)
-        params = await cls.sign_wbi_params(params={'mid': str(mid), 'w_webid': render_data.access_id})
+        params = await cls.sign_wbi_params(params={'mid': str(mid)})
         data = await cls._get_json(url=url, params=params)
         return User.model_validate(data)
 

--- a/src/utils/bilibili_api/models/__init__.py
+++ b/src/utils/bilibili_api/models/__init__.py
@@ -49,7 +49,6 @@ from .user import (
     Account,
     User,
     UserLiveRoom,
-    UserSpaceRenderData,
     VipInfo,
 )
 
@@ -85,7 +84,6 @@ __all__ = [
     'User',
     'UserLiveRoom',
     'UserSearchResult',
-    'UserSpaceRenderData',
     'VideoSearchResult',
     'VipInfo',
 ]

--- a/src/utils/bilibili_api/models/user.py
+++ b/src/utils/bilibili_api/models/user.py
@@ -93,15 +93,9 @@ class User(BaseBilibiliResponse):
         return self.data.name
 
 
-class UserSpaceRenderData(BaseBilibiliModel):
-    """space.bilibili.com 页面 __RENDER_DATA__ 元素内容"""
-    access_id: str
-
-
 __all__ = [
     'Account',
     'User',
     'UserLiveRoom',
-    'UserSpaceRenderData',
     'VipInfo',
 ]


### PR DESCRIPTION
因wbi已不再需要w_webid，故移除相关代码

相关issues：https://github.com/SocialSisterYi/bilibili-API-collect/issues/1107#issuecomment-2828458578